### PR TITLE
Fix NA warning in tidyr::separate

### DIFF
--- a/R/cxy_geocoder.R
+++ b/R/cxy_geocoder.R
@@ -43,7 +43,7 @@ cxy_geocoder <- function(.data, timeout){
   } else {
 
     # split and coerce class of coords
-    df <- tidyr::separate(df, "V6", c("lon", "lat"), sep = ",")
+    df <- tidyr::separate(df, "V6", c("lon", "lat"), sep = ",", fill = 'right')
     df <- dplyr::mutate(df,
                         lon = as.numeric(lon),
                         lat = as.numeric(lat))


### PR DESCRIPTION
I approached this all wrong. Let us learn from my mistake.

The original issue (#7) was that we were getting a warning because tidyr::separate was filling the blanks with NAs. This was I believe due to tidyr update 0.8.0:
> separate() gets improved warning message when pieces aren't as expected (#375).

I'm curious as to how we passed the CRAN checks and CI builds, since version 0.8.0 was on CRAN 2018-01-29. I could be wrong about the specific version change, but I digress.

The first instinct I had was to wrap it in `suppressWarnings({})` but we agreed that's a risky move. Instead, I opted to rewrite the function in anticipation of filling gaps with NAs. This would have worked, but we realized it was much slower and added another dependency. No way some R code is going to compete with a Cpp method.

To the original point, I looked for a solution, ignorant to the actual source of the problem. Finally, I was wise enough to look at documentation and realize that `separate` has an argument for filling `NA`s, what I finally expected.

Compared to all of the afore-attempts, this fixes the issue at no sacrifice to speed, package size or future debugging. Please accept this PR as the best solution to addressing #7 